### PR TITLE
fix: get tsconfig in each pkg for monorepos

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -123,6 +123,23 @@ async function parseTreeRecursive(
   });
 }
 
+function findPackageRoot(dirName: string, packageFileName = 'package.json') {
+  let currentDir = dirName;
+  while (currentDir !== path.dirname(currentDir)) {
+    const packageFilePath = path.join(currentDir, packageFileName);
+    if (fs.existsSync(packageFilePath)) {
+      return currentDir;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+  return '';
+}
+type CompilerOptionsByPkg = {
+  compilerOptions: ts.CompilerOptions;
+  host: ts.CompilerHost;
+};
+const compilerOptionsByPkg = new Map<string, CompilerOptionsByPkg>();
+
 /**
  * @param entries - the entry glob list
  * @param options
@@ -139,14 +156,23 @@ export async function parseDependencyTree(
   const fullOptions = normalizeOptions(options);
   let resolve = simpleResolver;
   if (options.tsconfig) {
-    const compilerOptions = ts.parseJsonConfigFileContent(
-      ts.readConfigFile(options.tsconfig, ts.sys.readFile).config,
-      ts.sys,
-      path.dirname(options.tsconfig),
-    ).options;
-
-    const host = ts.createCompilerHost(compilerOptions);
     resolve = async (context, request, extensions) => {
+      const root = findPackageRoot(context);
+      if (!compilerOptionsByPkg.has(root)) {
+        let _compilerOptions = ts.parseJsonConfigFileContent(
+          ts.readConfigFile(path.join(root, 'tsconfig.json'), ts.sys.readFile)
+            .config,
+          ts.sys,
+          root,
+        ).options;
+        compilerOptionsByPkg.set(root, {
+          compilerOptions: _compilerOptions,
+          host: ts.createCompilerHost(_compilerOptions),
+        });
+      }
+      const { compilerOptions, host } = compilerOptionsByPkg.get(
+        root,
+      ) as CompilerOptionsByPkg;
       const module = ts.resolveModuleName(
         request,
         path.join(context, 'index.ts'),


### PR DESCRIPTION
Added support for retrieving individual tsconfig.json files for each package within the monorepo. Previously, a single tsconfig.json file was applied from the invoking package, resulting in a unified rule for aliases across all packages. Now, each package can use its own tsconfig.json with unique aliases, allowing for more flexible build configurations per package